### PR TITLE
feat: add support for Github Teams in the whitelist

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   modules-download-mode: vendor
-  go: '1.21.4'
+  go: '1.22.1'
 
 linters:
   enable:

--- a/.traefik.yml
+++ b/.traefik.yml
@@ -19,3 +19,5 @@ testData:
       - 996
     logins:
       - luizfonseca
+    teams:
+      - 876255

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM golang:1.21.4-alpine3.17 AS builder
+FROM golang:1.22.2-alpine3.19 AS builder
 
 RUN apk add --no-cache ca-certificates && update-ca-certificates
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ providing a more secure way for users to access protected routes.
 ## Quick Start (Docker)
 
 1. Create a GitHub OAuth App
-   
+
    - See: https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app
    - Set the Authorization callback URL to `http://<traefik-github-oauth-server-host>/oauth/redirect`
 
 2. Run the Traefik GitHub OAuth server
-   
+
    ```sh
    docker run -d --name traefik-github-oauth-server \
      --network <traefik-proxy-network> \
@@ -31,9 +31,9 @@ providing a more secure way for users to access protected routes.
    ```
 
 3. Install the Traefik GitHub OAuth plugin
-   
+
     Add this snippet in the Traefik Static configuration
-   
+
    ```yaml
    experimental:
      plugins:
@@ -43,12 +43,13 @@ providing a more secure way for users to access protected routes.
    ```
 
 4. Run your App
-   
+
    ```sh
    docker run -d --whoami test \
      --network <traefik-proxy-network> \
      --label 'traefik.http.middlewares.whoami-github-oauth.plugin.github-oauth.apiBaseUrl=http://traefik-github-oauth-server' \
      --label 'traefik.http.middlewares.whoami-github-oauth.plugin.github-oauth.whitelist.logins[0]=luizfonseca' \
+     --label 'traefik.http.middlewares.whoami-github-oauth.plugin.github-oauth.whitelist.teams[0]=827726' \
      --label 'traefik.http.routers.whoami.rule=Host(`whoami.example.com`)' \
      --label 'traefik.http.routers.whoami.middlewares=whoami-github-oauth' \
     traefik/whoami
@@ -85,12 +86,16 @@ jwtSecretKey: optional_secret_key
 logLevel: info
 # whitelist
 whitelist:
-  # The list of GitHub user ids that in the whitelist
+  # The list of GitHub user ids that are whitelisted to access the resources
   ids:
     - 996
-  # The list of GitHub user logins that in the whitelist
+  # The list of GitHub user logins that are whitelisted to access the resources
   logins:
     - luizfonseca
+
+  # The list of Github Teams that are whitelisted to access the resources
+  teams:
+    - 988772
 ```
 
 ## License

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/luizfonseca/traefik-github-oauth-plugin
 
-go 1.21.4
+go 1.22.1
 
 require (
 	github.com/go-chi/render v1.0.3

--- a/internal/app/traefik-github-oauth-server/model/model.go
+++ b/internal/app/traefik-github-oauth-server/model/model.go
@@ -19,9 +19,10 @@ type ResponseGenerateOAuthPageURL struct {
 }
 
 type ResponseGetAuthResult struct {
-	RedirectURI     string `json:"redirect_uri"`
-	GitHubUserID    string `json:"github_user_id"`
-	GitHubUserLogin string `json:"github_user_login"`
+	RedirectURI     string   `json:"redirect_uri"`
+	GitHubUserID    string   `json:"github_user_id"`
+	GitHubUserLogin string   `json:"github_user_login"`
+	GithubTeamIDs   []string `json:"github_team_ids"`
 }
 
 type ResponseError struct {
@@ -29,8 +30,9 @@ type ResponseError struct {
 }
 
 type AuthRequest struct {
-	RedirectURI     string `json:"redirect_uri"`
-	AuthURL         string `json:"auth_url"`
-	GitHubUserID    string `json:"github_user_id"`
-	GitHubUserLogin string `json:"github_user_login"`
+	RedirectURI     string   `json:"redirect_uri"`
+	AuthURL         string   `json:"auth_url"`
+	GitHubUserID    string   `json:"github_user_id"`
+	GitHubUserLogin string   `json:"github_user_login"`
+	GithubTeamIDs   []string `json:"github_team_ids"`
 }

--- a/internal/pkg/jwt/jwt.go
+++ b/internal/pkg/jwt/jwt.go
@@ -32,10 +32,17 @@ func ParseTokenString(tokenString, key string) (*PayloadUser, error) {
 		return nil, err
 	}
 	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
+		teamFromClaims := claims["teams"].([]interface{})
+		teams := make([]string, len(teamFromClaims))
+
+		for i, v := range teamFromClaims {
+			teams[i] = v.(string)
+		}
+
 		return &PayloadUser{
 			Id:    claims["id"].(string),
 			Login: claims["login"].(string),
-			Teams: claims["teams"].([]string),
+			Teams: teams,
 		}, nil
 	} else {
 		return nil, fmt.Errorf("invalid token")

--- a/internal/pkg/jwt/jwt.go
+++ b/internal/pkg/jwt/jwt.go
@@ -7,14 +7,16 @@ import (
 )
 
 type PayloadUser struct {
-	Id    string `json:"id"`
-	Login string `json:"login"`
+	Id    string   `json:"id"`
+	Login string   `json:"login"`
+	Teams []string `json:"teams"`
 }
 
-func GenerateJwtTokenString(id, login, key string) (string, error) {
+func GenerateJwtTokenString(id string, login string, teamIds []string, key string) (string, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"id":    id,
 		"login": login,
+		"teams": teamIds,
 	})
 	return token.SignedString([]byte(key))
 }
@@ -33,6 +35,7 @@ func ParseTokenString(tokenString, key string) (*PayloadUser, error) {
 		return &PayloadUser{
 			Id:    claims["id"].(string),
 			Login: claims["login"].(string),
+			Teams: claims["teams"].([]string),
 		}, nil
 	} else {
 		return nil, fmt.Errorf("invalid token")

--- a/internal/pkg/jwt/jwt_test.go
+++ b/internal/pkg/jwt/jwt_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var testTeams = []string{"team1", "team2"}
+
 const (
 	id    = "12345"
 	login = "testuser"
@@ -14,7 +16,7 @@ const (
 
 func TestGenerateJwtTokenString(t *testing.T) {
 	// execution
-	tokenString, err := GenerateJwtTokenString(id, login, key)
+	tokenString, err := GenerateJwtTokenString(id, login, testTeams, key)
 
 	// assertion
 	assert.NoError(t, err)
@@ -23,7 +25,7 @@ func TestGenerateJwtTokenString(t *testing.T) {
 
 func TestParseTokenString(t *testing.T) {
 	// setup
-	tokenString, _ := GenerateJwtTokenString(id, login, key)
+	tokenString, _ := GenerateJwtTokenString(id, login, testTeams, key)
 
 	// execution
 	payload, err := ParseTokenString(tokenString, key)
@@ -32,6 +34,7 @@ func TestParseTokenString(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, id, payload.Id)
 	assert.Equal(t, login, payload.Login)
+	assert.Equal(t, testTeams, payload.Teams)
 }
 
 func TestParseTokenString_InvalidToken(t *testing.T) {
@@ -48,7 +51,7 @@ func TestParseTokenString_InvalidToken(t *testing.T) {
 
 func TestParseTokenString_InvalidKey(t *testing.T) {
 	// setup
-	tokenString, _ := GenerateJwtTokenString(id, login, key)
+	tokenString, _ := GenerateJwtTokenString(id, login, testTeams, key)
 	invalidKey := "invalidkey"
 
 	// execution


### PR DESCRIPTION
- Upgrade to Golang 1.22.1
- Add support for GH teams, without erroring (as it's optional in comparison with ID/username)
- Tweaks to the JWT to include the user team IDs.



- Addresses #18 