### PR TITLE
fix: allow additional github scopes to be requested

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ providing a more secure way for users to access protected routes.
 |------------------------------|-------------------------------------------------------------------------------|---------|----------|
 | `GITHUB_OAUTH_CLIENT_ID`     | The GitHub OAuth App client id                                                |         | Yes      |
 | `GITHUB_OAUTH_CLIENT_SECRET` | The GitHub OAuth App client secret                                            |         | Yes      |
-| `GITHUB_OAUTH_SCOPES`        | Additional scopes to be added to the Oauth workflow. "user" is always added.   | "user"  | No       |
+| `GITHUB_OAUTH_SCOPES`        | Additional scopes to be added to the Oauth workflow.                          |         | No       |
 | `API_BASE_URL`               | The base URL of the Traefik GitHub OAuth server                               |         | Yes      |
 | `API_SECRET_KEY`             | The api secret key. You can ignore this if you are using the internal network |         | No       |
 | `SERVER_ADDRESS`             | The server address                                                            | `:80`   | No       |
@@ -107,8 +107,8 @@ You can follow the steps in the [GitHub documentation](https://docs.github.com/e
 
 #### OAuth Scopes
 - For `ids` and `logins` you don't need extra scopes.
-- For `teams` you will need to request the `read:org`, `user` or `repo` scopes from the user. See the [documentation](https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#list-teams-for-the-authenticated-user).
-    - You can do so by updating the `GITHUB_OAUTH_SCOPES` environment variable with the desired additional scopes, e.g. `GITHUB_OAUTH_SCOPES="repo,read:org"` via the **Server Configuration**.
+- For `teams` you might need to request the `read:org` scope from the user. See the [documentation](https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#list-teams-for-the-authenticated-user).
+    - You can do so by updating the `GITHUB_OAUTH_SCOPES` environment variable with the desired additional scopes, e.g. `GITHUB_OAUTH_SCOPES="read:org"` via the **Server Configuration**.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ providing a more secure way for users to access protected routes.
 |------------------------------|-------------------------------------------------------------------------------|---------|----------|
 | `GITHUB_OAUTH_CLIENT_ID`     | The GitHub OAuth App client id                                                |         | Yes      |
 | `GITHUB_OAUTH_CLIENT_SECRET` | The GitHub OAuth App client secret                                            |         | Yes      |
+| `GITHUB_OAUTH_SCOPES`        | Additional scopes to be added to the Oauth workflow. "user" is always added.   | "user"  | No       |
 | `API_BASE_URL`               | The base URL of the Traefik GitHub OAuth server                               |         | Yes      |
 | `API_SECRET_KEY`             | The api secret key. You can ignore this if you are using the internal network |         | No       |
 | `SERVER_ADDRESS`             | The server address                                                            | `:80`   | No       |
@@ -89,6 +90,7 @@ whitelist:
   # The list of GitHub user ids that are whitelisted to access the resources
   ids:
     - 996
+
   # The list of GitHub user logins that are whitelisted to access the resources
   logins:
     - luizfonseca
@@ -106,6 +108,7 @@ You can follow the steps in the [GitHub documentation](https://docs.github.com/e
 #### OAuth Scopes
 - For `ids` and `logins` you don't need extra scopes.
 - For `teams` you will need to request the `read:org`, `user` or `repo` scopes from the user. See the [documentation](https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#list-teams-for-the-authenticated-user).
+    - You can do so by updating the `GITHUB_OAUTH_SCOPES` environment variable with the desired additional scopes, e.g. `GITHUB_OAUTH_SCOPES="repo,read:org"` via the **Server Configuration**.
 
 
 ## License

--- a/internal/app/traefik-github-oauth-server/app.go
+++ b/internal/app/traefik-github-oauth-server/app.go
@@ -63,6 +63,7 @@ func NewApp(
 			ClientID:     config.GitHubOAuthClientID,
 			ClientSecret: config.GitHubOAuthClientSecret,
 			Endpoint:     oauth2github.Endpoint,
+			Scopes:       config.GithubOauthScopes,
 		},
 		AuthRequestManager: authRequestManager,
 		Logger:             logger,

--- a/internal/app/traefik-github-oauth-server/config.go
+++ b/internal/app/traefik-github-oauth-server/config.go
@@ -2,6 +2,8 @@ package traefik_github_oauth_server
 
 import (
 	"os"
+	"slices"
+	"strings"
 
 	"github.com/spf13/cast"
 )
@@ -15,6 +17,7 @@ type Config struct {
 	GitHubOAuthClientID     string
 	GitHubOAuthClientSecret string
 	Addr                    string
+	GithubOauthScopes       []string
 }
 
 func envWithDefault(key string, defaultValue string) string {
@@ -23,6 +26,20 @@ func envWithDefault(key string, defaultValue string) string {
 		return defaultValue
 	}
 	return value
+}
+
+func githubOauthScopeConfigs() []string {
+	// Default scopes
+	scopes := []string{"user"}
+
+	// Add additional scopes
+	scopesFromEnv := os.Getenv("GITHUB_OAUTH_SCOPES")
+	if scopesFromEnv != "" {
+		sp := strings.Split(scopesFromEnv, ",")
+		scopes = slices.Concat(scopes, sp)
+	}
+
+	return scopes
 }
 
 func NewConfigFromEnv() *Config {
@@ -34,5 +51,6 @@ func NewConfigFromEnv() *Config {
 		LogLevel:                envWithDefault("LOG_LEVEL", "INFO"),
 		GitHubOAuthClientID:     os.Getenv("GITHUB_OAUTH_CLIENT_ID"),
 		GitHubOAuthClientSecret: os.Getenv("GITHUB_OAUTH_CLIENT_SECRET"),
+		GithubOauthScopes:       githubOauthScopeConfigs(),
 	}
 }

--- a/internal/app/traefik-github-oauth-server/config.go
+++ b/internal/app/traefik-github-oauth-server/config.go
@@ -2,7 +2,6 @@ package traefik_github_oauth_server
 
 import (
 	"os"
-	"slices"
 	"strings"
 
 	"github.com/spf13/cast"
@@ -29,17 +28,12 @@ func envWithDefault(key string, defaultValue string) string {
 }
 
 func githubOauthScopeConfigs() []string {
-	// Default scopes
-	scopes := []string{"user"}
-
-	// Add additional scopes
 	scopesFromEnv := os.Getenv("GITHUB_OAUTH_SCOPES")
 	if scopesFromEnv != "" {
-		sp := strings.Split(scopesFromEnv, ",")
-		scopes = slices.Concat(scopes, sp)
+		return strings.Split(scopesFromEnv, ",")
 	}
 
-	return scopes
+	return []string{}
 }
 
 func NewConfigFromEnv() *Config {


### PR DESCRIPTION
- Some of the new features (e.g. checking for team membership) might require additional scopes to be "explicitly requested" in the oauth workflow
- You can now use `GITHUB_OAUTH_SCOPES=<value>,<value>` in the server configuration to update the workflow to mention the additional scopes if necessary (in most cases, it's not).