### PR TITLE
fix: backwards compatibility when missing `teams: []string{}` in the JWT

### DIFF
--- a/internal/pkg/jwt/jwt.go
+++ b/internal/pkg/jwt/jwt.go
@@ -32,11 +32,21 @@ func ParseTokenString(tokenString, key string) (*PayloadUser, error) {
 		return nil, err
 	}
 	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
-		teamFromClaims := claims["teams"].([]interface{})
+		var teamFromClaims []interface{}
+
+		switch claims["teams"].(type) {
+		case []interface{}:
+			teamFromClaims = claims["teams"].([]interface{})
+		case nil:
+			// Backwards compatible with previous tokens, nothing to do
+		}
+
 		teams := make([]string, len(teamFromClaims))
 
 		for i, v := range teamFromClaims {
-			teams[i] = v.(string)
+			if stringValue, ok := v.(string); ok {
+				teams[i] = stringValue
+			}
 		}
 
 		return &PayloadUser{

--- a/internal/pkg/jwt/jwt_test.go
+++ b/internal/pkg/jwt/jwt_test.go
@@ -1,6 +1,7 @@
 package jwt
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,6 +36,22 @@ func TestParseTokenString(t *testing.T) {
 	assert.Equal(t, id, payload.Id)
 	assert.Equal(t, login, payload.Login)
 	assert.Equal(t, testTeams, payload.Teams)
+}
+
+func TestParseTokenStringWithoutTeams(t *testing.T) {
+	// setup
+	tokenString, _ := GenerateJwtTokenString(id, login, []string{}, key)
+
+	fmt.Printf("tokenString: %s\n", tokenString)
+
+	// execution
+	payload, err := ParseTokenString(tokenString, key)
+
+	// assertion
+	assert.NoError(t, err)
+	assert.Equal(t, id, payload.Id)
+	assert.Equal(t, login, payload.Login)
+	assert.Equal(t, payload.Teams, []string{})
 }
 
 func TestParseTokenString_InvalidToken(t *testing.T) {

--- a/internal/pkg/jwt/jwt_test.go
+++ b/internal/pkg/jwt/jwt_test.go
@@ -1,7 +1,6 @@
 package jwt
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,11 +37,23 @@ func TestParseTokenString(t *testing.T) {
 	assert.Equal(t, testTeams, payload.Teams)
 }
 
-func TestParseTokenStringWithoutTeams(t *testing.T) {
+func TestParseTokenString_EmptyTeams(t *testing.T) {
 	// setup
 	tokenString, _ := GenerateJwtTokenString(id, login, []string{}, key)
 
-	fmt.Printf("tokenString: %s\n", tokenString)
+	// execution
+	payload, err := ParseTokenString(tokenString, key)
+
+	// assertion
+	assert.NoError(t, err)
+	assert.Equal(t, id, payload.Id)
+	assert.Equal(t, login, payload.Login)
+	assert.Equal(t, payload.Teams, []string{})
+}
+
+func TestParseTokenString_NoTeams(t *testing.T) {
+	// setup
+	tokenString, _ := GenerateJwtTokenString(id, login, nil, key)
 
 	// execution
 	payload, err := ParseTokenString(tokenString, key)


### PR DESCRIPTION
- With the introduction of the `teams` in the JWT claim, we erroneously didn't parse tokens that didn't contain the value (previous tokens)
- This PR fixes it by converting the `nil` value to an empty `[]interface{}` type