### PR TITLE
feat: support file secrets for env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ providing a more secure way for users to access protected routes.
 | `SERVER_ADDRESS`             | The server address                                                            | `:80`   | No       |
 | `DEBUG_MODE`                 | Enable debug mode and set log level to debug                                  | `false` | No       |
 | `LOG_LEVEL`                  | The log level, Available values: debug, info, warn, error                     | `info`  | No       |
+You can append `_FILE` to any of the environment variable names to load the value from a file.
+
+E.g. `GITHUB_OAUTH_CLIENT_SECRET_FILE=/run/secrets/github_oauth_client_SECRET` where the content of the file `/run/secrets/github_oauth_client_SECRET` will be used as the environment variable.
 
 ### Middleware Configuration
 

--- a/internal/app/traefik-github-oauth-server/config.go
+++ b/internal/app/traefik-github-oauth-server/config.go
@@ -19,14 +19,21 @@ type Config struct {
 	GithubOauthScopes       []string
 }
 
-func envString(key string) string {
-	fileKey := key + "_FILE"
-	if value := os.Getenv(fileKey); value != "" {
+func envFromFile(key string) string {
+	fileEnvKey := key + "_FILE"
+
+	if value := os.Getenv(fileEnvKey); value != "" {
 		content, err := os.ReadFile(value)
-		if err != nil {
-			return os.Getenv(key)
+		if err == nil {
+			return strings.TrimSpace(string(content))
 		}
-		return strings.TrimSpace(string(content))
+	}
+	return ""
+}
+
+func envString(key string) string {
+	if value := envFromFile(key); value != "" {
+		return value
 	}
 	return os.Getenv(key)
 }

--- a/internal/app/traefik-github-oauth-server/config.go
+++ b/internal/app/traefik-github-oauth-server/config.go
@@ -20,15 +20,15 @@ type Config struct {
 }
 
 func envString(key string) string {
-	value := os.Getenv(key)
-	if strings.HasSuffix(key, "_FILE") && value != "" {
+	fileKey := key + "_FILE"
+	if value := os.Getenv(fileKey); value != "" {
 		content, err := os.ReadFile(value)
 		if err != nil {
-			return ""
+			return os.Getenv(key)
 		}
 		return strings.TrimSpace(string(content))
 	}
-	return value
+	return os.Getenv(key)
 }
 
 func envWithDefault(key string, defaultValue string) string {

--- a/internal/app/traefik-github-oauth-server/config.go
+++ b/internal/app/traefik-github-oauth-server/config.go
@@ -19,8 +19,20 @@ type Config struct {
 	GithubOauthScopes       []string
 }
 
-func envWithDefault(key string, defaultValue string) string {
+func envString(key string) string {
 	value := os.Getenv(key)
+	if strings.HasSuffix(key, "_FILE") && value != "" {
+		content, err := os.ReadFile(value)
+		if err != nil {
+			return ""
+		}
+		return strings.TrimSpace(string(content))
+	}
+	return value
+}
+
+func envWithDefault(key string, defaultValue string) string {
+	value := envString(key)
 	if value == "" {
 		return defaultValue
 	}
@@ -28,7 +40,7 @@ func envWithDefault(key string, defaultValue string) string {
 }
 
 func githubOauthScopeConfigs() []string {
-	scopesFromEnv := os.Getenv("GITHUB_OAUTH_SCOPES")
+	scopesFromEnv := envString("GITHUB_OAUTH_SCOPES")
 	if scopesFromEnv != "" {
 		return strings.Split(scopesFromEnv, ",")
 	}
@@ -38,13 +50,13 @@ func githubOauthScopeConfigs() []string {
 
 func NewConfigFromEnv() *Config {
 	return &Config{
-		ApiBaseURL:              os.Getenv("API_BASE_URL"),
-		ApiSecretKey:            os.Getenv("API_SECRET_KEY"),
-		ServerAddress:           os.Getenv("SERVER_ADDRESS"),
-		DebugMode:               cast.ToBool(os.Getenv("DEBUG_MODE")),
+		ApiBaseURL:              envString("API_BASE_URL"),
+		ApiSecretKey:            envString("API_SECRET_KEY"),
+		ServerAddress:           envString("SERVER_ADDRESS"),
+		DebugMode:               cast.ToBool(envString("DEBUG_MODE")),
 		LogLevel:                envWithDefault("LOG_LEVEL", "INFO"),
-		GitHubOAuthClientID:     os.Getenv("GITHUB_OAUTH_CLIENT_ID"),
-		GitHubOAuthClientSecret: os.Getenv("GITHUB_OAUTH_CLIENT_SECRET"),
+		GitHubOAuthClientID:     envString("GITHUB_OAUTH_CLIENT_ID"),
+		GitHubOAuthClientSecret: envString("GITHUB_OAUTH_CLIENT_SECRET"),
 		GithubOauthScopes:       githubOauthScopeConfigs(),
 	}
 }


### PR DESCRIPTION
While trying to use this plugin, I encountered the issue that you need to pass the environnement variables, notably the `GITHUB_OAUTH_CLIENT_SECRET`, as text and that passing a file does not work.

The issue is Docker secrets are only sent as a file and not as plain text, and in particular `GITHUB_OAUTH_CLIENT_SECRET` often requires the use of Docker secrets in a docker-compose scenario.

This PR adds a simple `envString` function that checks if the there is a file with some content named "[ENV_NAME_FILE]", and in that case returns the content of the file to the config, and if that file does not exist, it returns the default value of the env variable "[ENV_NAME]".

We use "_FILE" as it's a mentioned way to handle this in the [official docker documentation](https://docs.docker.com/engine/swarm/secrets/#build-support-for-docker-secrets-into-your-images).