### PR TITLE
feat: allow users to configure cookie/jwt expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ apiSecretKey: optional_secret_key_if_not_on_the_internal_network
 authPath: /_auth
 # optional jwt secret key, if not set, the plugin will generate a random key
 jwtSecretKey: optional_secret_key
+# optional jwt expiration in hours, defaults to 24 hours
+jwtExpirationInHours: 24
+
 # The log level, defaults to info
 # Available values: debug, info, warn, error
 logLevel: info

--- a/internal/pkg/jwt/jwt.go
+++ b/internal/pkg/jwt/jwt.go
@@ -2,6 +2,7 @@ package jwt
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/golang-jwt/jwt/v4"
 )
@@ -12,11 +13,12 @@ type PayloadUser struct {
 	Teams []string `json:"teams"`
 }
 
-func GenerateJwtTokenString(id string, login string, teamIds []string, key string) (string, error) {
+func GenerateJwtTokenString(id string, login string, teamIds []string, key string, exp time.Time) (string, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"id":    id,
 		"login": login,
 		"teams": teamIds,
+		"exp":   jwt.NewNumericDate(exp.Add(time.Second * 60)),
 	})
 	return token.SignedString([]byte(key))
 }
@@ -33,6 +35,11 @@ func ParseTokenString(tokenString, key string) (*PayloadUser, error) {
 	}
 	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
 		var teamFromClaims []interface{}
+
+		// Check for expiration time
+		// if claims.Valid() != nil {
+		// 	return nil, fmt.Errorf("token is expired")
+		// }
 
 		switch claims["teams"].(type) {
 		case []interface{}:

--- a/internal/pkg/jwt/jwt.go
+++ b/internal/pkg/jwt/jwt.go
@@ -18,7 +18,8 @@ func GenerateJwtTokenString(id string, login string, teamIds []string, key strin
 		"id":    id,
 		"login": login,
 		"teams": teamIds,
-		"exp":   jwt.NewNumericDate(exp.Add(time.Second * 60)),
+		// buffer of time to expire token is 10 seconds from the set time
+		"exp": jwt.NewNumericDate(exp.Add(time.Second * 60)),
 	})
 	return token.SignedString([]byte(key))
 }

--- a/internal/pkg/jwt/jwt.go
+++ b/internal/pkg/jwt/jwt.go
@@ -18,7 +18,7 @@ func GenerateJwtTokenString(id string, login string, teamIds []string, key strin
 		"id":    id,
 		"login": login,
 		"teams": teamIds,
-		// buffer of time to expire token is 10 seconds from the set time
+		// buffer of time to expire token is 60 seconds from the set time
 		"exp": jwt.NewNumericDate(exp.Add(time.Second * 60)),
 	})
 	return token.SignedString([]byte(key))


### PR DESCRIPTION
Allow users to pass `jwtExpirationInHours` via configuration to allow for longer auth windows.

*Important*: currently skipping the jwt validation of the `exp` attribute. 


Try to address #58 and #54 